### PR TITLE
Lift upper bound on python pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "napari-adaptive-painting"
 dynamic = ["version"]
 description = "Propagate label annotations in Napari."
 readme = "README.md"
-requires-python = ">=3.9,<3.10"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [{ name = "Mallory Wittwer", email = "mallory.wittwer@epfl.ch" }]
 


### PR DESCRIPTION
Hi! Cool plugin! 
I was surprised when I couldn't install it and then realized it was pinned to just python 3.9.
Nothing in your requirements is limited to python 3.9, so I lift the pin to allow broader usage.
I've tested locally with python 3.12 and everything works nicely!